### PR TITLE
ReactiveCats

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,4 +46,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
     implementation "io.reactivex.rxjava2:rxjava:2.2.21"
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
 }

--- a/app/src/main/java/otus/homework/reactivecats/CatsService.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsService.kt
@@ -1,10 +1,10 @@
 package otus.homework.reactivecats
 
-import io.reactivex.Single
+import io.reactivex.Observable
 import retrofit2.http.GET
 
 interface CatsService {
 
     @GET("random?animal_type=cat")
-    fun getCatFact(): Single<Fact>
+    fun getCatFact(): Observable<Fact>
 }

--- a/app/src/main/java/otus/homework/reactivecats/CatsService.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsService.kt
@@ -1,10 +1,10 @@
 package otus.homework.reactivecats
 
-import retrofit2.Call
+import io.reactivex.Single
 import retrofit2.http.GET
 
 interface CatsService {
 
     @GET("random?animal_type=cat")
-    fun getCatFact(): Call<Fact>
+    fun getCatFact(): Single<Fact>
 }

--- a/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
 
 class CatsViewModel(
     catsService: CatsService,
@@ -18,24 +18,24 @@ class CatsViewModel(
     private val _catsLiveData = MutableLiveData<Result>()
     val catsLiveData: LiveData<Result> = _catsLiveData
 
-    init {
-        catsService.getCatFact().enqueue(object : Callback<Fact> {
-            override fun onResponse(call: Call<Fact>, response: Response<Fact>) {
-                if (response.isSuccessful && response.body() != null) {
-                    _catsLiveData.value = Success(response.body()!!)
-                } else {
-                    _catsLiveData.value = Error(
-                        response.errorBody()?.string() ?: context.getString(
-                            R.string.default_error_text
-                        )
-                    )
-                }
-            }
+    private val compositeDisposable = CompositeDisposable()
 
-            override fun onFailure(call: Call<Fact>, t: Throwable) {
-                _catsLiveData.value = ServerError
-            }
-        })
+    init {
+        compositeDisposable.add(
+            catsService.getCatFact()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSuccess { _catsLiveData.value = Success(it)   }
+                .doOnError {
+                    _catsLiveData.value = Error(it.message ?: context.getString(R.string.default_error_text))
+                }
+                .subscribe()
+        )
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.dispose()
     }
 
     fun getFacts() {}

--- a/app/src/main/java/otus/homework/reactivecats/DiContainer.kt
+++ b/app/src/main/java/otus/homework/reactivecats/DiContainer.kt
@@ -2,6 +2,7 @@ package otus.homework.reactivecats
 
 import android.content.Context
 import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 
 class DiContainer {
@@ -10,6 +11,7 @@ class DiContainer {
         Retrofit.Builder()
             .baseUrl("https://cat-fact.herokuapp.com/facts/")
             .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
             .build()
     }
 

--- a/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
+++ b/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
@@ -3,6 +3,7 @@ package otus.homework.reactivecats
 import android.content.Context
 import io.reactivex.Flowable
 import io.reactivex.Single
+import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
 class LocalCatFactsGenerator(
@@ -15,7 +16,7 @@ class LocalCatFactsGenerator(
      * обернутую в подходящий стрим(Flowable/Single/Observable и т.п)
      */
     fun generateCatFact(): Single<Fact> {
-        return Single.never()
+        return Single.just(Fact(context.resources.getStringArray(R.array.local_cat_facts)[Random.nextInt(5)]))
     }
 
     /**
@@ -24,7 +25,8 @@ class LocalCatFactsGenerator(
      * Если вновь заэмиченный Fact совпадает с предыдущим - пропускаем элемент.
      */
     fun generateCatFactPeriodically(): Flowable<Fact> {
-        val success = Fact(context.resources.getStringArray(R.array.local_cat_facts)[Random.nextInt(5)])
-        return Flowable.empty()
+        return Flowable.interval(2000, TimeUnit.MILLISECONDS)
+            .map { Fact(context.resources.getStringArray(R.array.local_cat_facts)[Random.nextInt(5)]) }
+            .distinctUntilChanged()
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,6 @@
         android:id="@+id/fact_textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textColor="@color/black"
         android:textSize="24sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Что сделано
- Переведите сетевой запрос с retrofit.Call на RX цепочку. Для этого подключите Retrofit адаптер, поменяйте возвращаемые типы функций
- Поменяйте логику в CatsViewModel.kt с колбеков на RX. Логику обработки успеха/ошибки из коллбека необходимо перенести в терминальные коллбеки RX цепочки. Не забудьте очистить подписки когда ViewModel уничтожается
- Реализуйте функцию otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFact, так, чтобы она возвращала Fact со случайной строкой из массива строк R.array.local_cat_facts обернутую в подходящий стрим(Flowable/Single/Observable и т.п)
- Реализуйте функцию otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFactPeriodically так, чтобы она эмитила Fact со случайной строкой из массива строк R.array.local_cat_facts каждые 2000 миллисекунд. Если вновь заэмиченный Fact совпадает с предыдущим - пропускаем элемент.
- Реализуйте функцию otus.homework.reactivecats.CatsViewModel#getFacts следующим образом: каждые 2 секунды идем в сеть за новым фактом, если сетевой запрос завершился неуспешно, то в качестве фоллбека идем за фактом в уже реализованный otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFact.