### PR TITLE
Homework 1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,4 +46,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
     implementation "io.reactivex.rxjava2:rxjava:2.2.21"
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
 }

--- a/app/src/main/java/otus/homework/reactivecats/CatsService.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsService.kt
@@ -1,10 +1,10 @@
 package otus.homework.reactivecats
 
-import retrofit2.Call
+import io.reactivex.Single
 import retrofit2.http.GET
 
 interface CatsService {
 
     @GET("random?animal_type=cat")
-    fun getCatFact(): Call<Fact>
+    fun getCatFact(): Single<Fact>
 }

--- a/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.Disposable
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import retrofit2.HttpException
 
@@ -16,12 +16,12 @@ class CatsViewModel(
     context: Context
 ) : ViewModel() {
 
-    private var getCatFactDisposable: Disposable? = null
+    private var onClearedCompositDisposable = CompositeDisposable()
     private val _catsLiveData = MutableLiveData<Result>()
     val catsLiveData: LiveData<Result> = _catsLiveData
 
     init {
-        getCatFactDisposable = catsService.getCatFact()
+        catsService.getCatFact()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
@@ -40,13 +40,15 @@ class CatsViewModel(
                         else -> ServerError
                     }
                 }
-            )
+            ).also(onClearedCompositDisposable::add)
     }
 
-    fun getFacts() {}
+    fun getFacts() {
+
+    }
 
     override fun onCleared() {
-        getCatFactDisposable?.dispose()
+        onClearedCompositDisposable?.dispose()
     }
 }
 

--- a/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
@@ -5,9 +5,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.Disposable
+import io.reactivex.schedulers.Schedulers
+import retrofit2.HttpException
 
 class CatsViewModel(
     catsService: CatsService,
@@ -15,30 +16,38 @@ class CatsViewModel(
     context: Context
 ) : ViewModel() {
 
+    private var getCatFactDisposable: Disposable? = null
     private val _catsLiveData = MutableLiveData<Result>()
     val catsLiveData: LiveData<Result> = _catsLiveData
 
     init {
-        catsService.getCatFact().enqueue(object : Callback<Fact> {
-            override fun onResponse(call: Call<Fact>, response: Response<Fact>) {
-                if (response.isSuccessful && response.body() != null) {
-                    _catsLiveData.value = Success(response.body()!!)
-                } else {
-                    _catsLiveData.value = Error(
-                        response.errorBody()?.string() ?: context.getString(
-                            R.string.default_error_text
-                        )
-                    )
+        getCatFactDisposable = catsService.getCatFact()
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { catFact ->
+                    _catsLiveData.value = Success(catFact)
+                },
+                { throwable ->
+                    _catsLiveData.value = when(throwable) {
+                        is HttpException -> {
+                            Error(
+                                throwable.response()?.errorBody()?.string() ?: context.getString(
+                                    R.string.default_error_text
+                                )
+                            )
+                        }
+                        else -> ServerError
+                    }
                 }
-            }
-
-            override fun onFailure(call: Call<Fact>, t: Throwable) {
-                _catsLiveData.value = ServerError
-            }
-        })
+            )
     }
 
     fun getFacts() {}
+
+    override fun onCleared() {
+        getCatFactDisposable?.dispose()
+    }
 }
 
 class CatsViewModelFactory(

--- a/app/src/main/java/otus/homework/reactivecats/DiContainer.kt
+++ b/app/src/main/java/otus/homework/reactivecats/DiContainer.kt
@@ -2,6 +2,7 @@ package otus.homework.reactivecats
 
 import android.content.Context
 import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 
 class DiContainer {
@@ -10,6 +11,7 @@ class DiContainer {
         Retrofit.Builder()
             .baseUrl("https://cat-fact.herokuapp.com/facts/")
             .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
             .build()
     }
 

--- a/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
+++ b/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
@@ -1,14 +1,9 @@
 package otus.homework.reactivecats
 
 import android.content.Context
-import android.util.Log
-import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
-import io.reactivex.FlowableOnSubscribe
-import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
-import java.lang.Thread.sleep
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 

--- a/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
+++ b/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
@@ -1,12 +1,20 @@
 package otus.homework.reactivecats
 
 import android.content.Context
+import android.util.Log
+import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
+import io.reactivex.FlowableOnSubscribe
+import io.reactivex.Scheduler
 import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
+import java.lang.Thread.sleep
+import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
+
 class LocalCatFactsGenerator(
-    private val context: Context
+    private val context : Context,
 ) {
 
     /**
@@ -14,7 +22,7 @@ class LocalCatFactsGenerator(
      * чтобы она возвращала Fact со случайной строкой  из массива строк R.array.local_cat_facts
      * обернутую в подходящий стрим(Flowable/Single/Observable и т.п)
      */
-    fun generateCatFact(): Single<Fact> {
+    fun generateCatFact() : Single<Fact> {
         return Single.fromCallable {
             val localFacts = context.resources.getStringArray(R.array.local_cat_facts)
             val randomFactIndex = Random.nextInt(0, localFacts.size)
@@ -27,8 +35,12 @@ class LocalCatFactsGenerator(
      * чтобы она эмитила Fact со случайной строкой из массива строк R.array.local_cat_facts каждые 2000 миллисекунд.
      * Если вновь заэмиченный Fact совпадает с предыдущим - пропускаем элемент.
      */
-    fun generateCatFactPeriodically(): Flowable<Fact> {
-        val success = Fact(context.resources.getStringArray(R.array.local_cat_facts)[Random.nextInt(5)])
-        return Flowable.empty()
+    fun generateCatFactPeriodically() : Flowable<Fact> {
+        return Flowable.interval(2000, TimeUnit.MILLISECONDS, Schedulers.io())
+            .map {
+                val facts = context.resources.getStringArray(R.array.local_cat_facts)
+                Fact(facts[Random.nextInt(5)])
+            }
+            .distinct()
     }
 }

--- a/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
+++ b/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
@@ -15,7 +15,11 @@ class LocalCatFactsGenerator(
      * обернутую в подходящий стрим(Flowable/Single/Observable и т.п)
      */
     fun generateCatFact(): Single<Fact> {
-        return Single.never()
+        return Single.fromCallable {
+            val localFacts = context.resources.getStringArray(R.array.local_cat_facts)
+            val randomFactIndex = Random.nextInt(0, localFacts.size)
+            Fact(localFacts[randomFactIndex])
+        }
     }
 
     /**


### PR DESCRIPTION
- [x] 1. Переведите сетевой запрос с retrofit.Call на RX цепочку. Для этого подключите Retrofit адаптер, поменяйте возвращаемые типы функций
- [x] 2. Поменяйте логику в CatsViewModel.kt с колбеков на RX. Логику обработки успеха/ошибки из коллбека необходимо перенести в терминальные коллбеки RX цепочки. Не забудьте очистить подписки когда ViewModel уничтожается
- [x] 3. Реализуйте функцию otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFact, так, чтобы она возвращала Fact со случайной строкой из массива строк R.array.local_cat_facts обернутую в подходящий стрим(Flowable/Single/Observable и т.п)
- [x] 4. Реализуйте функцию otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFactPeriodically так, чтобы она эмитила Fact со случайной строкой из массива строк R.array.local_cat_facts каждые 2000 миллисекунд. Если вновь заэмиченный Fact совпадает с предыдущим - пропускаем элемент.
- [x] 5. Реализуйте функцию otus.homework.reactivecats.CatsViewModel#getFacts следующим образом: каждые 2 секунды идем в сеть за новым фактом, если сетевой запрос завершился неуспешно, то в качестве фоллбека идем за фактом в уже реализованный otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFact.