### PR TITLE
feat(hw): migrate project to rxjava

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,4 +46,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
     implementation "io.reactivex.rxjava2:rxjava:2.2.21"
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
 }

--- a/app/src/main/java/otus/homework/reactivecats/CatsService.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsService.kt
@@ -1,10 +1,10 @@
 package otus.homework.reactivecats
 
-import retrofit2.Call
+import io.reactivex.Observable
 import retrofit2.http.GET
 
 interface CatsService {
 
     @GET("random?animal_type=cat")
-    fun getCatFact(): Call<Fact>
+    fun getCatFact(): Observable<Fact>
 }

--- a/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
+++ b/app/src/main/java/otus/homework/reactivecats/CatsViewModel.kt
@@ -1,13 +1,14 @@
 package otus.homework.reactivecats
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
 
 class CatsViewModel(
     catsService: CatsService,
@@ -15,30 +16,43 @@ class CatsViewModel(
     context: Context
 ) : ViewModel() {
 
+    private val tag = javaClass.simpleName
     private val _catsLiveData = MutableLiveData<Result>()
     val catsLiveData: LiveData<Result> = _catsLiveData
+    private val subscriptionDisposables: CompositeDisposable = CompositeDisposable()
 
     init {
-        catsService.getCatFact().enqueue(object : Callback<Fact> {
-            override fun onResponse(call: Call<Fact>, response: Response<Fact>) {
-                if (response.isSuccessful && response.body() != null) {
-                    _catsLiveData.value = Success(response.body()!!)
-                } else {
-                    _catsLiveData.value = Error(
-                        response.errorBody()?.string() ?: context.getString(
-                            R.string.default_error_text
-                        )
-                    )
-                }
-            }
 
-            override fun onFailure(call: Call<Fact>, t: Throwable) {
-                _catsLiveData.value = ServerError
-            }
-        })
+        val catFactsSubscription = catsService
+            .getCatFact()
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { fact ->
+                    _catsLiveData.value = Success(fact)
+                },
+                { error ->
+                    if (error is retrofit2.HttpException) {
+                        Log.e(tag, "ServerError: ${error.code()}")
+                        _catsLiveData.value = ServerError
+                    } else {
+                        Log.e(tag, "Error: $error")
+                        _catsLiveData.value = Error(
+                            error.message ?: context.getString(R.string.default_error_text)
+                        )
+                    }
+                }
+            )
+
+        subscriptionDisposables.add(catFactsSubscription)
     }
 
     fun getFacts() {}
+
+    override fun onCleared() {
+        super.onCleared()
+        subscriptionDisposables.dispose()
+    }
 }
 
 class CatsViewModelFactory(

--- a/app/src/main/java/otus/homework/reactivecats/DiContainer.kt
+++ b/app/src/main/java/otus/homework/reactivecats/DiContainer.kt
@@ -2,6 +2,7 @@ package otus.homework.reactivecats
 
 import android.content.Context
 import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 
 class DiContainer {
@@ -10,6 +11,7 @@ class DiContainer {
         Retrofit.Builder()
             .baseUrl("https://cat-fact.herokuapp.com/facts/")
             .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
             .build()
     }
 

--- a/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
+++ b/app/src/main/java/otus/homework/reactivecats/LocalCatFactsGenerator.kt
@@ -9,13 +9,18 @@ class LocalCatFactsGenerator(
     private val context: Context
 ) {
 
+    private val localCatFacts = context.resources.getStringArray(R.array.local_cat_facts)
+
     /**
      * Реализуйте функцию otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFact так,
      * чтобы она возвращала Fact со случайной строкой  из массива строк R.array.local_cat_facts
      * обернутую в подходящий стрим(Flowable/Single/Observable и т.п)
      */
     fun generateCatFact(): Single<Fact> {
-        return Single.never()
+        return Single.fromCallable {
+            val randomFact = localCatFacts[Random.Default.nextInt(localCatFacts.size)]
+            Fact(randomFact)
+        }
     }
 
     /**


### PR DESCRIPTION
# ReactiveCats

1. Переведите сетевой запрос с `retrofit.Call` на RX цепочку. Для этого подключите Retrofit адаптер, поменяйте возвращаемые типы функций

2. Поменяйте логику в `CatsViewModel.kt` с колбеков на RX. Логику обработки успеха/ошибки из коллбека необходимо перенести в терминальные коллбеки RX цепочки. Не забудьте очистить подписки когда `ViewModel` уничтожается

3. Реализуйте функцию `otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFact`, так, чтобы она возвращала `Fact` со случайной строкой  из массива строк `R.array.local_cat_facts` обернутую в подходящий стрим(`Flowable`/`Single`/`Observable` и т.п)

4. Реализуйте функцию `otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFactPeriodically` так, чтобы она эмитила `Fact` со случайной строкой из массива строк `R.array.local_cat_facts` каждые 2000 миллисекунд. Если вновь заэмиченный Fact совпадает с предыдущим - пропускаем элемент.

5. Реализуйте функцию `otus.homework.reactivecats.CatsViewModel#getFacts` следующим образом:  каждые 2 секунды идем в сеть за новым фактом, если сетевой запрос завершился неуспешно, то в качестве фоллбека идем за фактом в уже реализованный `otus.homework.reactivecats.LocalCatFactsGenerator#generateCatFact`.
